### PR TITLE
Add a deprecation notice to the index.

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -1,3 +1,11 @@
+<div class="alert alert-block alert-warning">
+  <p>
+    This site is deprecated.  See
+    <a href="http://https://www.vagrantup.com/downloads.html">https://www.vagrantup.com/downloads.html</a>
+    for current versions.
+  </p>
+</div>
+
 <p>
 	This is the Vagrant download site. Below you will find a list of the
 	available versions to download, sorted in descending order so that the


### PR DESCRIPTION
This site is currently misleading because it claims to hold the latest
version, but actually doesn't since the download site was moved.

Addresses https://github.com/mitchellh/vagrant/issues/4773

Screenshot:
![screen shot 2014-11-21 at 11 28 38](https://cloud.githubusercontent.com/assets/5560/5141779/94d352f4-7171-11e4-8387-626e60868b91.png)
